### PR TITLE
feat: add OIDC logout flow support

### DIFF
--- a/src/controller/index.ts
+++ b/src/controller/index.ts
@@ -7,6 +7,7 @@ import { prepareProviderRoutes } from "./provider/prepare";
 import { wellKnownRoute } from "./provider/well-known";
 import { healthcheckRoute } from "./root/healthcheck";
 import { landingPage } from "./root/landing";
+import { logoutCallbackRoute } from "./root/logoutCallback";
 import { oauthCallbackRoute } from "./root/oauthCallback";
 import { type ProviderRouterState } from "./type";
 
@@ -24,6 +25,7 @@ export const controller = (app: Koa) => {
     return next();
   });
   router.get("/oauth/callback", oauthCallbackRoute);
+  router.get("/oauth/logout-callback", logoutCallbackRoute);
   router.get("/", landingPage);
   router.all(config.app.healthcheck.path, healthcheckRoute);
 

--- a/src/controller/provider/[...catchAll].ts
+++ b/src/controller/provider/[...catchAll].ts
@@ -13,6 +13,8 @@ import { type ProviderMiddleware } from "../type";
  * This is the main logic of Charon.
  *
  * It will catch, validate, and forward request from a client to a provider depending of the config.
+ *
+ * Supports both authorization flows (redirect_uri) and OIDC logout flows (post_logout_redirect_uri).
  */
 export const catchAllRoutes =
   (excludedPaths: string[]): ProviderMiddleware =>
@@ -26,15 +28,27 @@ export const catchAllRoutes =
         return;
       }
       const method = ctx.request.method;
-      const { redirect_uri = ctx.session!.originalRedirectUri, ...others } = (
+      const allParams = (
         method === "GET" ? ctx.request.query : ctx.request.body
       ) as Record<string, string>;
+
+      // Detect OIDC logout flow by the presence of post_logout_redirect_uri
+      const isLogout = "post_logout_redirect_uri" in allParams;
+
+      // Extract the URI to validate: post_logout_redirect_uri for logout, redirect_uri for auth
+      const clientUri = isLogout
+        ? allParams.post_logout_redirect_uri
+        : allParams.redirect_uri ?? ctx.session!.originalRedirectUri;
+
+      const { redirect_uri: _ignoreRedirectUri, post_logout_redirect_uri: _ignorePostLogout, ...others } = allParams;
+
       const clients = getCharonClients();
 
       logServer("Middleware incoming request", pathname, method, ctx.session, {
         cookies: ctx.headers.cookie,
         authorization: ctx.header.authorization,
-        redirect_uri,
+        clientUri,
+        isLogout,
         clients,
         ...others,
       });
@@ -45,21 +59,31 @@ export const catchAllRoutes =
         }
         const shouldPass = client.wildcards.some(wildcard => {
           const regex = wildcardToRegex(wildcard);
-          return regex.test(redirect_uri);
+          return regex.test(clientUri);
         });
-        logServer({ shouldPass, redirect_uri });
+        logServer({ shouldPass, clientUri, isLogout });
         if (shouldPass) {
           const provider = getProvider(client.provider);
 
-          const params = {
-            ...others,
-            redirect_uri: config.app.charonUrl("/oauth/callback"),
-          };
-
+          // Store session for the callback to redirect back to the original URI
           ctx.session!.provider = client.provider;
           ctx.session!.client = client;
-          ctx.session!.originalRedirectUri = redirect_uri;
+          ctx.session!.originalRedirectUri = clientUri;
           ctx.session!.params = others;
+
+          // Build params for the provider:
+          // - Auth flow: rewrite redirect_uri to Charon's /oauth/callback
+          // - Logout flow: rewrite post_logout_redirect_uri to Charon's /oauth/logout-callback
+          const params = isLogout
+            ? {
+                ...others,
+                post_logout_redirect_uri: config.app.charonUrl("/oauth/logout-callback"),
+              }
+            : {
+                ...others,
+                redirect_uri: config.app.charonUrl("/oauth/callback"),
+              };
+
           const headers: Record<string, string | string[]> = {};
           if (ctx.headers.authorization) {
             headers["Authorization"] = ctx.headers.authorization;
@@ -73,7 +97,7 @@ export const catchAllRoutes =
 
           if (method === "POST") {
             const redirectURL = provider.getIssuer(pathname);
-            logServer("POST REDIRECT", { redirectURL, ctxsession: ctx.session, params });
+            logServer("POST REDIRECT", { redirectURL, ctxsession: ctx.session, params, isLogout });
             const response = await axios.post<unknown>(redirectURL, params, {
               headers,
             });
@@ -83,7 +107,7 @@ export const catchAllRoutes =
           } else if (method === "GET") {
             const redirectURL = provider.getIssuer(pathname, params);
 
-            logServer("GET REDIRECT", { redirectURL, ctxsession: ctx.session, params });
+            logServer("GET REDIRECT", { redirectURL, ctxsession: ctx.session, params, isLogout });
 
             Object.entries(headers).forEach(([key, value]) => {
               ctx.set(key, value);

--- a/src/controller/root/callbackFactory.ts
+++ b/src/controller/root/callbackFactory.ts
@@ -1,0 +1,37 @@
+import type Router from "@koa/router";
+
+import { logServer } from "../../utils/logger";
+
+/**
+ * Create a callback route handler for OAuth or OIDC logout flows.
+ *
+ * Both auth and logout callbacks follow the same pattern:
+ * 1. Check session exists (set by catch-all during the initial request)
+ * 2. Retrieve the original client URI from session
+ * 3. Redirect back to the client with query params from the provider
+ */
+export const createCallbackRoute = (label: string): Router.Middleware => ctx => {
+  if (!ctx.session?.client) {
+    ctx.throw(400, "Session not found");
+    return;
+  }
+  try {
+    const client = ctx.session.client;
+    const originalRedirectUri = ctx.session.originalRedirectUri;
+    const params = { ...ctx.query } as Record<string, string>;
+
+    logServer(`CALLBACK FROM provider (${label})`, {
+      cookie: ctx.request.headers.cookie,
+      url: ctx.request.url,
+      method: ctx.request.method,
+      client,
+      originalRedirectUri,
+      params,
+    });
+
+    ctx.redirect(`${originalRedirectUri}?${new URLSearchParams(params).toString()}`);
+  } catch (error) {
+    console.error(`Error handling ${label} callback:`, error);
+    ctx.throw(500, "Internal Server Error");
+  }
+};

--- a/src/controller/root/logoutCallback.ts
+++ b/src/controller/root/logoutCallback.ts
@@ -1,6 +1,4 @@
-import type Router from "@koa/router";
-
-import { logServer } from "../../utils/logger";
+import { createCallbackRoute } from "./callbackFactory";
 
 /**
  * Handle post-logout callback from OIDC provider.
@@ -9,28 +7,4 @@ import { logServer } from "../../utils/logger";
  * with the `state` query param. Charon then redirects back to the
  * original client application URL stored in session.
  */
-export const logoutCallbackRoute: Router.Middleware = ctx => {
-  if (!ctx.session?.client) {
-    ctx.throw(400, "Session not found");
-    return;
-  }
-  try {
-    const client = ctx.session.client;
-    const originalRedirectUri = ctx.session.originalRedirectUri;
-    const params = { ...ctx.query } as Record<string, string>;
-
-    logServer("CALLBACK FROM OIDC provider (logout)", {
-      cookie: ctx.request.headers.cookie,
-      url: ctx.request.url,
-      method: ctx.request.method,
-      client,
-      originalRedirectUri,
-      params,
-    });
-
-    ctx.redirect(`${originalRedirectUri}?${new URLSearchParams(params).toString()}`);
-  } catch (error) {
-    console.error("Error handling logout callback:", error);
-    ctx.throw(500, "Internal Server Error");
-  }
-};
+export const logoutCallbackRoute = createCallbackRoute("logout");

--- a/src/controller/root/logoutCallback.ts
+++ b/src/controller/root/logoutCallback.ts
@@ -1,0 +1,36 @@
+import type Router from "@koa/router";
+
+import { logServer } from "../../utils/logger";
+
+/**
+ * Handle post-logout callback from OIDC provider.
+ *
+ * After the provider clears its session, it redirects the browser here
+ * with the `state` query param. Charon then redirects back to the
+ * original client application URL stored in session.
+ */
+export const logoutCallbackRoute: Router.Middleware = ctx => {
+  if (!ctx.session?.client) {
+    ctx.throw(400, "Session not found");
+    return;
+  }
+  try {
+    const client = ctx.session.client;
+    const originalRedirectUri = ctx.session.originalRedirectUri;
+    const params = { ...ctx.query } as Record<string, string>;
+
+    logServer("CALLBACK FROM OIDC provider (logout)", {
+      cookie: ctx.request.headers.cookie,
+      url: ctx.request.url,
+      method: ctx.request.method,
+      client,
+      originalRedirectUri,
+      params,
+    });
+
+    ctx.redirect(`${originalRedirectUri}?${new URLSearchParams(params).toString()}`);
+  } catch (error) {
+    console.error("Error handling logout callback:", error);
+    ctx.throw(500, "Internal Server Error");
+  }
+};

--- a/src/controller/root/oauthCallback.ts
+++ b/src/controller/root/oauthCallback.ts
@@ -1,37 +1,7 @@
-import type Router from "@koa/router";
-
-import { logServer } from "../../utils/logger";
+import { createCallbackRoute } from "./callbackFactory";
 
 /**
  * Handle callback for OAuth provider. Depends on cookie as it
  * should be the end of the "browser redirection" flow handled by Charon
  */
-export const oauthCallbackRoute: Router.Middleware = ctx => {
-  if (!ctx.session?.client) {
-    ctx.throw(400, "Session not found");
-    return;
-  }
-  try {
-    const client = ctx.session.client;
-    const originalRedirectUri = ctx.session.originalRedirectUri;
-    const params = { ...ctx.query } as Record<string, string>;
-
-    logServer("CALLBACK FROM OAuth provider", {
-      cookie: ctx.request.headers.cookie,
-      autorization: ctx.request.headers.authorization,
-      url: ctx.request.url,
-      method: ctx.request.method,
-      client,
-      originalRedirectUri,
-      params,
-    });
-
-    // TODO forward headers?
-
-    // Redirect to original client
-    ctx.redirect(`${originalRedirectUri}?${new URLSearchParams(params).toString()}`);
-  } catch (error) {
-    console.error("Error handling OAuth callback:", error);
-    ctx.throw(500, "Internal Server Error");
-  }
-};
+export const oauthCallbackRoute = createCallbackRoute("OAuth");


### PR DESCRIPTION
Links to https://github.com/SocialGouv/egapro/issues/3026

Par ailleurs, `https://egapro-charon.ovh.fabrique.social.gouv.fr/oauth/logout-callback` doit être enregistré comme `post_logout_redirect_uri` chez ProConnect via Démarches Simplifiées. Sans ça, ProConnect retournera `"post_logout_redirect_uri not registered"`.

## Summary

- **Catch-all middleware** now detects OIDC logout requests by the presence of `post_logout_redirect_uri` in query params
- For logout: rewrites `post_logout_redirect_uri` to Charon's new `/oauth/logout-callback` (same pattern as `redirect_uri` → `/oauth/callback` for auth)
- Does **not** add `redirect_uri` to logout requests (OIDC providers like ProConnect reject extra params on `end_session`)
- New **`/oauth/logout-callback`** route redirects the browser back to the original client app after the provider clears its session

## Problem

Charon's catch-all always added `redirect_uri` to forwarded requests, even for OIDC `end_session` calls. ProConnect (and other OIDC-compliant providers) reject unknown params on the `end_session` endpoint, causing a `server_error`.

Also, `post_logout_redirect_uri` was passed through as-is to the provider, meaning it contained the client's dynamic URL (e.g. a review app URL) instead of Charon's registered callback. The provider rejected it with "post_logout_redirect_uri not registered".

## How it works

```
Client App → Charon (catch-all detects post_logout_redirect_uri)
  → stores original URI in session
  → rewrites post_logout_redirect_uri to /oauth/logout-callback
  → forwards to OIDC provider

OIDC Provider → clears session → redirects to /oauth/logout-callback?state=xxx

Charon /oauth/logout-callback → reads session → redirects to original client app
```