### PR TITLE
feat(logout): OIDC RP-initiated logout proxy

### DIFF
--- a/src/controller/index.ts
+++ b/src/controller/index.ts
@@ -4,17 +4,37 @@ import type Koa from "koa";
 import { config } from "../config";
 import { catchAllRoutes } from "./provider/[...catchAll]";
 import { prepareProviderRoutes } from "./provider/prepare";
+import { sessionEndRoute } from "./provider/session-end";
 import { wellKnownRoute } from "./provider/well-known";
 import { healthcheckRoute } from "./root/healthcheck";
 import { landingPage } from "./root/landing";
 import { oauthCallbackRoute } from "./root/oauthCallback";
+import { oauthLogoutCallbackRoute } from "./root/oauthLogoutCallback";
 import { type ProviderRouterState } from "./type";
+
+// OIDC end_session_endpoint paths used by the upstream providers we know
+// about today:
+//   - agent-connect (current ProConnect via /api/v2)  → /session/end
+//   - proconnect-identite (panva/oidc-provider based) → /oauth/logout
+// The path that actually reaches us depends on what each provider's
+// well-known doc declares. Registering both routes against the same
+// handler keeps charon forward-compatible without per-provider wiring.
+const SESSION_END_PATHS = ["/session/end", "/oauth/logout"] as const;
 
 export const controller = (app: Koa) => {
   const providerRouter = new Router<ProviderRouterState>();
   providerRouter.use(prepareProviderRoutes);
   providerRouter.get("/.well-known/openid-configuration", wellKnownRoute);
-  providerRouter.all("/(.+)", catchAllRoutes(["/.well-known/openid-configuration"]));
+  for (const path of SESSION_END_PATHS) {
+    providerRouter.all(path, sessionEndRoute);
+  }
+  providerRouter.all(
+    "/(.+)",
+    catchAllRoutes([
+      "/.well-known/openid-configuration",
+      ...SESSION_END_PATHS,
+    ]),
+  );
 
   const router = new Router();
   router.use((ctx, next) => {
@@ -24,6 +44,7 @@ export const controller = (app: Koa) => {
     return next();
   });
   router.get("/oauth/callback", oauthCallbackRoute);
+  router.get("/oauth/logout/callback", oauthLogoutCallbackRoute);
   router.get("/", landingPage);
   router.all(config.app.healthcheck.path, healthcheckRoute);
 

--- a/src/controller/provider/session-end.ts
+++ b/src/controller/provider/session-end.ts
@@ -1,0 +1,78 @@
+import { getCharonClients } from "../../client/client";
+import { config } from "../../config";
+import { getProvider } from "../../provider";
+import { logServer } from "../../utils/logger";
+import { wildcardToRegex } from "../../utils/wildcard";
+import { type ProviderMiddleware } from "../type";
+
+/**
+ * Handle OIDC RP-initiated logout (`/{provider}/session/end`).
+ *
+ * Mirrors the dispatch logic of the catchAll handler but matches against
+ * `post_logout_redirect_uri` instead of `redirect_uri`. When a registered
+ * wildcard matches, we rewrite the URI to charon's own logout callback and
+ * stash the original in the session — same trick as for authorize callbacks,
+ * applied to the logout path.
+ *
+ * Without this handler the IdP session cookie can never be cleared from a
+ * dynamic-URL client (review apps): the upstream IdP refuses any
+ * `post_logout_redirect_uri` it has not seen registered, and we do not
+ * register every per-PR URL.
+ *
+ * If `post_logout_redirect_uri` is absent the request is just forwarded
+ * to the upstream — the user lands on the provider's default "logged out"
+ * page.
+ */
+export const sessionEndRoute: ProviderMiddleware = async (ctx, next) => {
+  try {
+    const pathname = ctx.state.path;
+    const providerType = ctx.state.providerType;
+    const method = ctx.request.method;
+    const {
+      post_logout_redirect_uri = ctx.session?.originalPostLogoutRedirectUri,
+      ...others
+    } = (method === "GET" ? ctx.request.query : ctx.request.body) as Record<
+      string,
+      string
+    >;
+
+    logServer("Session-end incoming", pathname, method, ctx.session, {
+      cookies: ctx.headers.cookie,
+      post_logout_redirect_uri,
+      ...others,
+    });
+
+    const provider = getProvider(providerType);
+    const params: Record<string, string> = { ...others };
+
+    if (post_logout_redirect_uri) {
+      const matchingClient = getCharonClients().find(
+        client =>
+          client.provider === providerType &&
+          client.wildcards.some(wildcard =>
+            wildcardToRegex(wildcard).test(post_logout_redirect_uri),
+          ),
+      );
+      if (!matchingClient) {
+        logServer("No client wildcard matches post_logout_redirect_uri", {
+          post_logout_redirect_uri,
+        });
+        await next();
+        return;
+      }
+      ctx.session!.provider = matchingClient.provider;
+      ctx.session!.client = matchingClient;
+      ctx.session!.originalPostLogoutRedirectUri = post_logout_redirect_uri;
+      params.post_logout_redirect_uri = config.app.charonUrl(
+        "/oauth/logout/callback",
+      );
+    }
+
+    const redirectURL = provider.getIssuer(pathname, params);
+    logServer("Session-end redirect", { redirectURL });
+    ctx.redirect(redirectURL);
+  } catch (error) {
+    console.error("Error handling session-end:", error);
+    ctx.throw(500, "Internal Server Error");
+  }
+};

--- a/src/controller/root/oauthLogoutCallback.ts
+++ b/src/controller/root/oauthLogoutCallback.ts
@@ -1,0 +1,41 @@
+import type Router from "@koa/router";
+
+import { logServer } from "../../utils/logger";
+
+/**
+ * OIDC RP-initiated logout callback. Hit by the upstream provider after
+ * the user's IdP session cookie has been cleared. Reads the original
+ * `post_logout_redirect_uri` from the session and redirects the browser
+ * back to the originating client.
+ *
+ * Mirrors `oauthCallbackRoute` for the authorize flow.
+ */
+export const oauthLogoutCallbackRoute: Router.Middleware = ctx => {
+  if (!ctx.session?.originalPostLogoutRedirectUri) {
+    ctx.throw(400, "Logout session not found");
+    return;
+  }
+  try {
+    const originalPostLogoutRedirectUri = ctx.session.originalPostLogoutRedirectUri;
+    const params = { ...ctx.query } as Record<string, string>;
+
+    logServer("LOGOUT CALLBACK FROM OAuth provider", {
+      cookie: ctx.request.headers.cookie,
+      url: ctx.request.url,
+      method: ctx.request.method,
+      originalPostLogoutRedirectUri,
+      params,
+    });
+
+    // Clear so a stale session can't redirect future logout-callbacks
+    ctx.session.originalPostLogoutRedirectUri = undefined;
+
+    const queryString = new URLSearchParams(params).toString();
+    ctx.redirect(
+      `${originalPostLogoutRedirectUri}${queryString ? `?${queryString}` : ""}`,
+    );
+  } catch (error) {
+    console.error("Error handling OAuth logout callback:", error);
+    ctx.throw(500, "Internal Server Error");
+  }
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ declare module "koa-session" {
   interface Session {
     client: CharonClient;
     originalRedirectUri: string;
+    originalPostLogoutRedirectUri?: string;
     params: Record<string, string | string[]>;
     provider: ProviderType;
   }


### PR DESCRIPTION
## Summary

- Adds the missing logout half of charon's OIDC dispatch — currently `session/end` returns 404, breaking RP-initiated logout for any client behind charon
- New `/{provider}/session/end` handler mirrors the existing catchAll dispatch logic but matches against `post_logout_redirect_uri` and rewrites it to charon's own `/oauth/logout/callback`, stashing the original in the session
- New `/oauth/logout/callback` reads the original URI from the session and redirects the browser back to the originating client
- `Session` type extended with `originalPostLogoutRedirectUri`

## Why

Without this, dynamic-URL clients (review apps) cannot perform OIDC RP-initiated logout: the upstream IdP refuses any `post_logout_redirect_uri` it has not seen registered, and we do not register every per-PR URL.

## Backward compatibility

`session/end` was previously a 404, so no client relied on its prior behaviour. The Egapro side (https://github.com/SocialGouv/egapro/pull/3347) consumes this once both deploys are out — deploy charon first.

## Test plan

- [ ] Deploy charon first, verify nothing regresses on existing flows (login, callback, well-known)
- [ ] Verify `/proconnecttest/session/end` returns a 302 to upstream `https://fca.integ01.dev-agentconnect.fr/api/v2/session/end` with rewritten `post_logout_redirect_uri`
- [ ] After egapro PR is deployed: verify end-to-end logout on alpha kills both the egapro cookie and the ProConnect SSO cookie (re-login should prompt for credentials, not auto-login)